### PR TITLE
Add permission bypass for player playtime checks in PlayerPlaytimeLis…

### DIFF
--- a/surf-playtime-checker/src/main/kotlin/dev/slne/surf/event/playtimechecker/listener/PlayerPlaytimeListener.kt
+++ b/surf-playtime-checker/src/main/kotlin/dev/slne/surf/event/playtimechecker/listener/PlayerPlaytimeListener.kt
@@ -15,6 +15,8 @@ import kotlin.jvm.optionals.getOrNull
 
 object PlayerPlaytimeListener : SurfProxyEventListener<SurfProxyPrePlaytimeUpdateEvent> {
 
+    private const val BYPASS_PERMISSION = "surf.event.playtimechecker.bypass"
+
     private val kickMessage = buildText {
         appendKickDisconnectMessage({
             variableValue("Du hast die maximale Spielzeit auf")
@@ -32,6 +34,8 @@ object PlayerPlaytimeListener : SurfProxyEventListener<SurfProxyPrePlaytimeUpdat
         val player = plugin.proxy.getPlayer(event.user.uuid).getOrNull() ?: return
         val serverName = player.currentServer.getOrNull()?.serverInfo?.name ?: return
 
+        if (player.hasPermission(BYPASS_PERMISSION)) return
+
         if (!serverName.isAllowed(event.newPlaytime.playtime)) {
             player.disconnect(kickMessage)
         }
@@ -39,6 +43,8 @@ object PlayerPlaytimeListener : SurfProxyEventListener<SurfProxyPrePlaytimeUpdat
 
     @Subscribe
     fun onServerPreConnect(event: ServerPreConnectEvent) = with(event) {
+        if (player.hasPermission(BYPASS_PERMISSION)) return
+
         val serverName = result.server.getOrNull()?.serverInfo?.name ?: return
         if (!serverName.isAllowed(player.uniqueId)) {
             result = ServerPreConnectEvent.ServerResult.denied()
@@ -48,6 +54,8 @@ object PlayerPlaytimeListener : SurfProxyEventListener<SurfProxyPrePlaytimeUpdat
 
     @Subscribe(order = PostOrder.LAST)
     fun onPlayerChooseInitialServer(event: PlayerChooseInitialServerEvent) = with(event) {
+        if (player.hasPermission(BYPASS_PERMISSION)) return
+
         val serverName = initialServer.getOrNull()?.serverInfo?.name ?: return
         if (!serverName.isAllowed(player.uniqueId)) {
             player.disconnect(kickMessage)


### PR DESCRIPTION
This pull request adds a permission-based bypass mechanism to the playtime checker functionality in the `PlayerPlaytimeListener` class. Players with the new `BYPASS_PERMISSION` can now bypass playtime restrictions and server connection rules.

### Permission-based bypass mechanism:

* [`surf-playtime-checker/src/main/kotlin/dev/slne/surf/event/playtimechecker/listener/PlayerPlaytimeListener.kt`](diffhunk://#diff-2698cbbeb7997b3980cc7adcbca27c7499864b4c23faebd21af4278ecb33d7b8R18-R19): Added a constant `BYPASS_PERMISSION` to define the permission string for bypassing playtime checks.
* [`surf-playtime-checker/src/main/kotlin/dev/slne/surf/event/playtimechecker/listener/PlayerPlaytimeListener.kt`](diffhunk://#diff-2698cbbeb7997b3980cc7adcbca27c7499864b4c23faebd21af4278ecb33d7b8R37-R47): Updated the `onServerPreConnect` method to skip playtime checks if the player has the `BYPASS_PERMISSION`.
* [`surf-playtime-checker/src/main/kotlin/dev/slne/surf/event/playtimechecker/listener/PlayerPlaytimeListener.kt`](diffhunk://#diff-2698cbbeb7997b3980cc7adcbca27c7499864b4c23faebd21af4278ecb33d7b8R57-R58): Updated the `onPlayerChooseInitialServer` method to allow players with `BYPASS_PERMISSION` to bypass initial server connection rules.